### PR TITLE
Fix typo and old function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ auto param = required("-nof").set(file,"") |
                               // if match is in conflict with other alternative "-nof"
                               .if_conflicted( [] { /* ... */ } );   
 ```
-The handler functions can also take an int, which is set to the argument index at which the event occured first:
+The handler functions can also take an int, which is set to the argument index at which the event occurred first:
 ```cpp
 string file = "default.txt";
 auto param = required("-nof").set(file,"") | 
@@ -1275,7 +1275,7 @@ if(parse(argc, argv, cli)) {
 }
 ```
 
-You could of course write down everything as one big expression (docstrings are ommitted)...:
+You could of course write down everything as one big expression (docstrings are omitted)...:
 ```cpp
 auto cli = (
     option("-v", "--verbose"),
@@ -1639,7 +1639,7 @@ The following definition for example, contains a subtle pitfall:
 auto cli = joinable(repeatable( option(",") , number("number", nums) ));
 //                                            ^^^ non-optional
 ```
-This will not match arguments like ```"1,"```. This is, because, if the repeat group is 'hit' by any of its child parameters, all non-optional parameters must also match wihtin the current 'repeat cycle'. So, if the parser hits the ```","``` it expects to find a number arg as well, because it is blocking (positional) and required. Only after seeing this number can it enter the next repeat cycle. Thus, the argument will not be matched, since joined matches are only valid if no error occured. Making the number optional solves the problem.
+This will not match arguments like ```"1,"```. This is, because, if the repeat group is 'hit' by any of its child parameters, all non-optional parameters must also match within the current 'repeat cycle'. So, if the parser hits the ```","``` it expects to find a number arg as well, because it is blocking (positional) and required. Only after seeing this number can it enter the next repeat cycle. Thus, the argument will not be matched, since joined matches are only valid if no error occured. Making the number optional solves the problem.
 
 
 ### Custom Value Filters
@@ -1892,7 +1892,7 @@ OPTIONS
     remove mode
         <regex>              regular expression filter
 
-    modification opererations
+    modification operations
         -c, --compress       compress database in-memory
         -u, --unique         keep only unique entries
         -m, --memlimit       max. size in RAM
@@ -1935,7 +1935,7 @@ auto cli = (
         value("regex") % "regular expression filter"
     ) | 
     ( command("modify"),
-        "modification opererations" % (
+        "modification operations" % (
             option("-c", "--compress") % "compress database in-memory",
             option("-u", "--unique")   % "keep only unique entries",
             option("-m", "--memlimit") % "max. size in RAM" & value("size")
@@ -1974,8 +1974,8 @@ auto fmt = doc_formatting{}
     .surround_repeat("", "...")                //surround repeatable parameters with these
     .surround_value("<", ">")                  //surround values with these
     .empty_label("")                           //used if parameter has no flags and no label
-    .max_alternative_flags_in_usage(1)         //max. # of flags per parameter in usage
-    .max_alternative_flags_in_doc(2)           //max. # of flags per parameter in detailed documentation
+    .max_flags_per_param_in_usage(1)           //max. # of flags per parameter in usage
+    .max_flags_per_param_in_doc(32)            //max. # of flags per parameter in detailed documentation
     .split_alternatives(true)                  //split usage into several lines for large alternatives
     .alternatives_min_split_size(3)            //min. # of parameters for separate usage line
     .merge_alternative_flags_with_common_prefix(false)  //-ab(cdxy|xy) instead of -abcdxy|-abxy

--- a/include/clipp.h
+++ b/include/clipp.h
@@ -1275,7 +1275,7 @@ public:
     }
     /** @brief adds an action that will be called if a required parameter
      *         is missing; the action will get called with the index of
-     *         the command line argument where the missing event occured first
+     *         the command line argument where the missing event occurred first
      */
     Derived&
     if_missing(index_action a) {
@@ -1296,7 +1296,7 @@ public:
     /** @brief adds an action that will be called if a parameter
      *         was matched, but was unreachable in the current scope;
      *         the action will be called with the index of
-     *         the command line argument where the problem occured
+     *         the command line argument where the problem occurred
      */
     Derived&
     if_blocked(index_action a) {
@@ -1315,9 +1315,9 @@ public:
         return *static_cast<Derived*>(this);
     }
     /** @brief adds an action that will be called if a parameter match
-     *         was in conflict with a different alternative paramete;
+     *         was in conflict with a different alternative parameter;
      *         the action will be called with the index of
-     *         the command line argument where the problem occuredr
+     *         the command line argument where the problem occurred
      */
     Derived&
     if_conflicted(index_action a) {
@@ -3339,7 +3339,7 @@ public:
 
     //---------------------------------------------------------------
     /** @brief returns augmented iterator for depth first searches
-     *  @details taverser knows end of iteration and can skip over children
+     *  @details traverser knows end of iteration and can skip over children
      */
     depth_first_traverser
     begin_dfs() const noexcept {
@@ -4640,7 +4640,7 @@ private:
 
     //-----------------------------------------------------
     /** @brief try to match 'arg' as concatenation of joinable parameters
-     *         that are all contaied within one group
+     *         that are all contained within one group
      */
     template<class ParamSelector>
     bool try_match_joined(const group& joinGroup, arg_string arg,
@@ -4910,7 +4910,7 @@ public:
     using iterator       = arg_mappings::const_iterator;
 
     //-----------------------------------------------------
-    /** @brief default: empty redult */
+    /** @brief default: empty result */
     parsing_result() = default;
 
     parsing_result(arg_mappings arg2param, missing_events misses):
@@ -4950,14 +4950,14 @@ public:
     }
 
     /** @brief returns true if any parsing error / violation of the
-     *         command line interface definition occured */
+     *         command line interface definition occurred */
     bool any_error() const noexcept {
         return unmapped_args_count() > 0 || !missing().empty() ||
                any_blocked() || any_conflict() || any_bad_repeat();
     }
 
     /** @brief returns true if no parsing error / violation of the
-     *         command line interface definition occured */
+     *         command line interface definition occurred */
     explicit operator bool() const noexcept { return !any_error(); }
 
     /** @brief access to range of missing parameter match events */
@@ -5243,7 +5243,7 @@ public:
     /** @brief determines column where documentation printing starts */
     doc_formatting&
     first_column(int col) {
-        //limit to [0,last_column] but push doc_column to the right if neccessary
+        //limit to [0,last_column] but push doc_column to the right if necessary
         if(col < 0) col = 0;
         else if(col > last_column()) col = last_column();
         if(col > doc_column()) doc_column(first_column());
@@ -5273,7 +5273,7 @@ public:
      */
     doc_formatting&
     last_column(int col) {
-        //limit to [first_column,oo] but push doc_column to the left if neccessary
+        //limit to [first_column,oo] but push doc_column to the left if necessary
         if(col < first_column()) col = first_column();
         if(col < doc_column()) doc_column(col);
         lastCol_ = col;
@@ -5332,7 +5332,7 @@ public:
     }
     const string& flag_separator() const noexcept { return flagSep_; }
 
-    /** @brief determnines strings surrounding parameter labels */
+    /** @brief determines strings surrounding parameter labels */
     doc_formatting&
     surround_labels(const string& prefix, const string& postfix) {
         labelPre_ = prefix;
@@ -5342,7 +5342,7 @@ public:
     const string& label_prefix()  const noexcept { return labelPre_; }
     const string& label_postfix() const noexcept { return labelPst_; }
 
-    /** @brief determnines strings surrounding optional parameters/groups */
+    /** @brief determines strings surrounding optional parameters/groups */
     doc_formatting&
     surround_optional(const string& prefix, const string& postfix) {
         optionPre_ = prefix;
@@ -5352,7 +5352,7 @@ public:
     const string& optional_prefix()  const noexcept { return optionPre_; }
     const string& optional_postfix() const noexcept { return optionPst_; }
 
-    /** @brief determnines strings surrounding repeatable parameters/groups */
+    /** @brief determines strings surrounding repeatable parameters/groups */
     doc_formatting&
     surround_repeat(const string& prefix, const string& postfix) {
         repeatPre_ = prefix;
@@ -5362,7 +5362,7 @@ public:
     const string& repeat_prefix()  const noexcept { return repeatPre_; }
     const string& repeat_postfix() const noexcept { return repeatPst_; }
 
-    /** @brief determnines strings surrounding exclusive groups */
+    /** @brief determines strings surrounding exclusive groups */
     doc_formatting&
     surround_alternatives(const string& prefix, const string& postfix) {
         alternPre_ = prefix;
@@ -5372,7 +5372,7 @@ public:
     const string& alternatives_prefix()  const noexcept { return alternPre_; }
     const string& alternatives_postfix() const noexcept { return alternPst_; }
 
-    /** @brief determnines strings surrounding alternative flags */
+    /** @brief determines strings surrounding alternative flags */
     doc_formatting&
     surround_alternative_flags(const string& prefix, const string& postfix) {
         alternFlagPre_ = prefix;
@@ -5382,7 +5382,7 @@ public:
     const string& alternative_flags_prefix()  const noexcept { return alternFlagPre_; }
     const string& alternative_flags_postfix() const noexcept { return alternFlagPst_; }
 
-    /** @brief determnines strings surrounding non-exclusive groups */
+    /** @brief determines strings surrounding non-exclusive groups */
     doc_formatting&
     surround_group(const string& prefix, const string& postfix) {
         groupPre_ = prefix;
@@ -5392,7 +5392,7 @@ public:
     const string& group_prefix()  const noexcept { return groupPre_; }
     const string& group_postfix() const noexcept { return groupPst_; }
 
-    /** @brief determnines strings surrounding joinable groups */
+    /** @brief determines strings surrounding joinable groups */
     doc_formatting&
     surround_joinable(const string& prefix, const string& postfix) {
         joinablePre_ = prefix;
@@ -6066,7 +6066,7 @@ private:
                             os << '\n';
                         }
                     }
-                    cur.pos.next_sibling(); //do not descend into memebers
+                    cur.pos.next_sibling(); //do not descend into members
                 }
                 cur.pos.invalidate(); //signal end-of-path
                 return;


### PR DESCRIPTION
This PR has only trivial modifications in docstrings and README:
- Update `max_alternative_flags_in_*()` to `max_flags_per_param_in_*()`; update the default value as well.
- Perform `aspell` to check spelling.

Many trailing whitespaces were found (by an Atom plugin), but I didn't remove them to keep this PR tractable. I hope you don't mind if I create another PR for that.