### PR TITLE
Remove an unused member: param_filter.exclusive_

### DIFF
--- a/include/clipp.h
+++ b/include/clipp.h
@@ -5346,7 +5346,6 @@ private:
     tri required_   = tri::either;
     tri blocking_   = tri::either;
     tri repeatable_ = tri::either;
-    tri exclusive_  = tri::either;
     tri hasDoc_     = tri::yes;
 };
 


### PR DESCRIPTION
Compiling with `clang++ -Wall` generates the warning:

```
../include/clipp.h:5349:9: warning: private field 'exclusive_' is not used [-Wunused-private-field]
    tri exclusive_  = tri::either;
        ^
1 warning generated.
```

It is not a serious problem, and `g++-8` does not complain anything. But clang users will be appreciate if this warning is silenced. I am not sure if removing `exclusive_` is the right solution for this library. The warning can be silenced also by implementing some forgotten feature with it, if any.