### PR TITLE
Create and install project pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,17 @@ write_basic_package_version_file(
   ${CONFIG_VERSION_FILE} COMPATIBILITY AnyNewerVersion
 )
 
+# Generate pkg-config .pc file
+set(PKGCONFIG_INSTALL_DIR
+  ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
+  CACHE PATH "Installation directory for pkg-config (${PROJECT_NAME}.pc) file"
+)
+configure_file(
+  "${PROJECT_NAME}.pc.in"
+  "${PROJECT_NAME}.pc"
+  @ONLY
+)
+
 install(DIRECTORY include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   FILES_MATCHING PATTERN "*.h"
@@ -34,6 +45,9 @@ install(EXPORT ${PROJECT_NAME}-config
 )
 install(FILES ${CONFIG_VERSION_FILE}
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+  DESTINATION ${PKGCONFIG_INSTALL_DIR}
 )
 
 option(BUILD_TESTING "Do not build tests by default" OFF)

--- a/clipp.pc.in
+++ b/clipp.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: Easy to use, powerful and expressive command line argument handling for C++11/14/17 contained in a single header file
+URL: https://github.com/muellan/clipp
+Version: @clipp_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
Even though this project is header-only, it can be helpful to provide a pkg-config file for build systems that support it.