### PR TITLE
Possibly fixes #44.

### DIFF
--- a/include/clipp.h
+++ b/include/clipp.h
@@ -5034,7 +5034,7 @@ private:
                 } else {
                     ++pos;
                 }
-            } else {  //param
+            } else if (pos.is_repeatable()) {  //non-repeatable param
                 if(pos->required()) {
                     action(pos);
                     ++pos;
@@ -5043,6 +5043,8 @@ private:
                 } else {
                     ++pos;
                 }
+            } else {
+                ++pos;
             }
         }
     }


### PR DESCRIPTION
This allows repeatable required options to have a single argument.

I'm not entirely confident that my change is correct. It may be better to apply the check sooner in the loop (prior to the group check).