### PR TITLE
Avoid installation if included as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,20 +21,31 @@ write_basic_package_version_file(
   ${CONFIG_VERSION_FILE} COMPATIBILITY AnyNewerVersion
 )
 
-install(DIRECTORY include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING PATTERN "*.h"
-)
-install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}-config
-)
-install(EXPORT ${PROJECT_NAME}-config
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
-  NAMESPACE ${PROJECT_NAME}::
-)
-install(FILES ${CONFIG_VERSION_FILE}
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
-)
+# Determine if clipp is built as a subproject (using add_subdirectory)
+# or if it is the master project.
+set(MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(MASTER_PROJECT ON)
+endif ()
+
+option(CLIPP_INSTALL "Generate the install target." ${MASTER_PROJECT})
+
+if(CLIPP_INSTALL)
+  install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+  )
+  install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-config
+  )
+  install(EXPORT ${PROJECT_NAME}-config
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+    NAMESPACE ${PROJECT_NAME}::
+  )
+  install(FILES ${CONFIG_VERSION_FILE}
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+  )
+endif()
 
 option(BUILD_TESTING "Do not build tests by default" OFF)
 include(CTest)

--- a/include/clipp.h
+++ b/include/clipp.h
@@ -155,6 +155,21 @@ namespace traits {
  * @brief function (class) signature type trait
  *
  *****************************************************************************/
+#if defined(__cpp_lib_is_invocable)
+template<class Fn, class Ret, class... Args>
+constexpr auto
+check_is_callable(int) -> decltype(
+    std::declval<Fn>()(std::declval<Args>()...),
+    std::integral_constant<bool,
+        std::is_same<Ret,typename std::invoke_result<Fn,Args...>::type>::value>{} );
+
+template<class Fn, class Ret>
+constexpr auto
+check_is_callable_without_arg(int) -> decltype(
+    std::declval<Fn>()(),
+    std::integral_constant<bool,
+        std::is_same<Ret,typename std::invoke_result<Fn>::type>::value>{} );
+#else
 template<class Fn, class Ret, class... Args>
 constexpr auto
 check_is_callable(int) -> decltype(
@@ -162,16 +177,17 @@ check_is_callable(int) -> decltype(
     std::integral_constant<bool,
         std::is_same<Ret,typename std::result_of<Fn(Args...)>::type>::value>{} );
 
-template<class,class,class...>
-constexpr auto
-check_is_callable(long) -> std::false_type;
-
 template<class Fn, class Ret>
 constexpr auto
 check_is_callable_without_arg(int) -> decltype(
     std::declval<Fn>()(),
     std::integral_constant<bool,
         std::is_same<Ret,typename std::result_of<Fn()>::type>::value>{} );
+#endif
+
+template<class,class,class...>
+constexpr auto
+check_is_callable(long) -> std::false_type;
 
 template<class,class>
 constexpr auto


### PR DESCRIPTION
When `clipp` is included as a subproject with `add_subdirectory`, the target is installed alongside the other targets of the main project. This is not always advisable, especially not if the main project installs an executable (so the headers file are not needed for users of the main target).

This PR provides a variable that the user can set to enable the install target. The variable is set by default on `ON` or `OFF` depending on whether the project is being built as a subproject or not.

A potential problem might arise for compatibility with existing clients that implicitly relied on the current behavior. They would have to explicitly set the `CLIPP_INSTALL` variable to `ON`. If this breaking change has to be avoided, another acceptable solution would be to simply set the variable to `ON` by default and at least let the client disable it if needed.