### PR TITLE
parse(): support both `const char **argv` and `char **argv` interface version

### DIFF
--- a/include/clipp.h
+++ b/include/clipp.h
@@ -5322,7 +5322,7 @@ parse(InputIterator first, InputIterator last, const group& cli)
  *
  *****************************************************************************/
 inline parsing_result
-parse(const int argc, char* argv[], const group& cli, arg_index offset = 1)
+parse(const int argc, const char** argv, const group& cli, arg_index offset = 1)
 {
     arg_list args;
     if(offset < argc) args.assign(argv+offset, argv+argc);
@@ -5330,6 +5330,16 @@ parse(const int argc, char* argv[], const group& cli, arg_index offset = 1)
     return detail::parse_and_execute(args, cli, offset);
 }
 
+/*************************************************************************//**
+ *
+ * @brief parses the standard array of command line arguments; omits argv[0]
+ *
+ *****************************************************************************/
+inline parsing_result
+parse(const int argc, char** argv, const group& cli, arg_index offset = 1)
+{
+	return parse(argc, (const char **)argv, cli, offset);
+}
 
 
 


### PR DESCRIPTION
parse(): support both `const char **argv` and `char **argv` interface version.

Some codebase have argv as `const char **argv` or `const char *argv[]` while others have it without the `const` modifier. This takes care of that and makes clipp a drop-in for both styles.

(cherrypicked off https://github.com/GerHobbelt/clipp master branch; original commit tested with latest MSVC2019)