### PR TITLE
fix for MSVC2019 going bonkers about the various `struct active`

### DIFF
--- a/test/alternative_groups_test.cpp
+++ b/test/alternative_groups_test.cpp
@@ -12,19 +12,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace alt_groups_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c &&
-                x.d == y.d && x.e == y.e && x.f == y.f );
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c &&
+				x.d == y.d && x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace alt_groups_test;
 
 
 //-------------------------------------------------------------------

--- a/test/alternative_options_test.cpp
+++ b/test/alternative_options_test.cpp
@@ -12,20 +12,26 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_):
-        a{a_}, b{b_}, c{c_}, d{d_}
-    {}
-    bool a = false, b = false, c = false, d = false;
-    bool conflict = false;
+namespace alt_options_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c &&
-                x.d == y.d && x.conflict == y.conflict);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+		bool conflict = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c &&
+				x.d == y.d && x.conflict == y.conflict);
+		}
+	};
+
+}
+
+using namespace alt_options_test;
 
 
 //-------------------------------------------------------------------

--- a/test/alternative_required_test.cpp
+++ b/test/alternative_required_test.cpp
@@ -12,21 +12,27 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_):
-        a{a_}, b{b_}, c{c_}, d{d_}
-    {}
-    bool a = false, b = false, c = false, d = false;
-    bool conflict = false;
-    std::size_t missing  = 0;
+namespace alt_req_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.conflict == y.conflict && x.missing == y.missing);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+		bool conflict = false;
+		std::size_t missing = 0;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.conflict == y.conflict && x.missing == y.missing);
+		}
+	};
+
+}
+
+using namespace alt_req_test;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test01.cpp
+++ b/test/blocking_test01.cpp
@@ -12,20 +12,26 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_, int i_ = 0) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}, i{i_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
-    int i = 0;
+namespace test01 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f && x.i == y.i);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_, int i_ = 0) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }, i{ i_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+		int i = 0;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f && x.i == y.i);
+		}
+	};
+
+}
+
+using namespace test01;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test02.cpp
+++ b/test/blocking_test02.cpp
@@ -12,20 +12,27 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_, int i_ = 0) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}, i{i_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
-    int i = 0;
+namespace test02 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f && x.i == y.i);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_, int i_ = 0) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }, i{ i_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+		int i = 0;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f && x.i == y.i);
+		}
+	};
+
+}
+
+using namespace test02;
+
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test03.cpp
+++ b/test/blocking_test03.cpp
@@ -12,20 +12,26 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_, int i_ = 0) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}, i{i_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
-    int i = 0;
+namespace test03 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f && x.i == y.i);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_, int i_ = 0) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }, i{ i_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+		int i = 0;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f && x.i == y.i);
+		}
+	};
+
+}
+
+using namespace test03;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test04.cpp
+++ b/test/blocking_test04.cpp
@@ -12,19 +12,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace test04 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace test04;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test05.cpp
+++ b/test/blocking_test05.cpp
@@ -12,19 +12,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace test05 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace test05;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test06.cpp
+++ b/test/blocking_test06.cpp
@@ -12,19 +12,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace test06 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace test06;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test07.cpp
+++ b/test/blocking_test07.cpp
@@ -13,19 +13,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace test07 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace test07;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test08.cpp
+++ b/test/blocking_test08.cpp
@@ -12,19 +12,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace test08 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c &&
-                x.d == y.d && x.e == y.e && x.f == y.f );
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c &&
+				x.d == y.d && x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace test08;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test09.cpp
+++ b/test/blocking_test09.cpp
@@ -12,27 +12,33 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(const std::string f_,
-           std::initializer_list<std::string> ts,
-           bool http_, bool ftp_,
-           std::initializer_list<std::string> ws) :
-           http{http_}, ftp{ftp_}, f{f_}, tgts{ts}, wrong{ws}
-    {}
-    bool http = false, ftp = false;
+namespace test09 {
 
-    std::string f;
-    std::vector<std::string> tgts;
-    std::vector<std::string> wrong;
+	struct active {
+		active() = default;
+		explicit
+			active(const std::string f_,
+				std::initializer_list<std::string> ts,
+				bool http_, bool ftp_,
+				std::initializer_list<std::string> ws) :
+			http{ http_ }, ftp{ ftp_ }, f{ f_ }, tgts{ ts }, wrong{ ws }
+		{}
+		bool http = false, ftp = false;
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return x.http == y.http && x.f == y.f &&
-               std::equal(x.tgts.begin(), x.tgts.end(), y.tgts.begin()) &&
-               std::equal(x.wrong.begin(), x.wrong.end(), y.wrong.begin());
-    }
-};
+		std::string f;
+		std::vector<std::string> tgts;
+		std::vector<std::string> wrong;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return x.http == y.http && x.f == y.f &&
+				std::equal(x.tgts.begin(), x.tgts.end(), y.tgts.begin()) &&
+				std::equal(x.wrong.begin(), x.wrong.end(), y.wrong.begin());
+		}
+	};
+
+}
+
+using namespace test09;
 
 
 //-------------------------------------------------------------------

--- a/test/blocking_test10.cpp
+++ b/test/blocking_test10.cpp
@@ -12,24 +12,30 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool n_, std::initializer_list<int> nums_,
-           bool s_, const std::string& str_)
-    :
-           str{str_}, nums{nums_}, n{n_}, s{s_}
-    {}
+namespace test10 {
 
-    std::string str;
-    std::vector<int> nums;
-    bool n = false, s = false;
+	struct active {
+		active() = default;
+		explicit
+			active(bool n_, std::initializer_list<int> nums_,
+				bool s_, const std::string& str_)
+			:
+			str{ str_ }, nums{ nums_ }, n{ n_ }, s{ s_ }
+		{}
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return x.n == y.n && x.s == y.s && x.str == y.str &&
-               std::equal(x.nums.begin(), x.nums.end(), y.nums.begin());
-    }
-};
+		std::string str;
+		std::vector<int> nums;
+		bool n = false, s = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return x.n == y.n && x.s == y.s && x.str == y.str &&
+				std::equal(x.nums.begin(), x.nums.end(), y.nums.begin());
+		}
+	};
+
+}
+
+using namespace test10;
 
 
 //-------------------------------------------------------------------

--- a/test/empty_args.cpp
+++ b/test/empty_args.cpp
@@ -12,21 +12,27 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool o_, std::string ov_ = "_", std::string pv_ = "_"):
-        o{o_}, ov{std::move(ov_)}, pv{std::move(pv_)}
-    {}
+namespace empty_args_test {
 
-    bool o = false;
-    std::string ov = "_";
-    std::string pv = "_";
+	struct active {
+		active() = default;
+		explicit
+			active(bool o_, std::string ov_ = "_", std::string pv_ = "_") :
+			o{ o_ }, ov{ std::move(ov_) }, pv{ std::move(pv_) }
+		{}
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.o == y.o && x.ov == y.ov && x.pv == y.pv);
-    }
-};
+		bool o = false;
+		std::string ov = "_";
+		std::string pv = "_";
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.o == y.o && x.ov == y.ov && x.pv == y.pv);
+		}
+	};
+
+}
+
+using namespace empty_args_test;
 
 
 //-------------------------------------------------------------------

--- a/test/joined_flags_test1.cpp
+++ b/test/joined_flags_test1.cpp
@@ -12,15 +12,21 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, bool b_): a{a_}, b{b_} {}
-    bool a = false, b = false;
+namespace flags_test01 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b);
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, bool b_) : a{ a_ }, b{ b_ } {}
+		bool a = false, b = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b);
+		}
+	};
+
+}
+
+using namespace flags_test01;
 
 
 //-------------------------------------------------------------------

--- a/test/joined_flags_test2.cpp
+++ b/test/joined_flags_test2.cpp
@@ -12,15 +12,22 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, bool b_): a{a_}, b{b_} {}
-    bool a = false, b = false;
+namespace flags_test02 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b);
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, bool b_) : a{ a_ }, b{ b_ } {}
+		bool a = false, b = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b);
+		}
+	};
+
+}
+
+using namespace flags_test02;
+
 
 
 //-------------------------------------------------------------------

--- a/test/joined_flags_test3.cpp
+++ b/test/joined_flags_test3.cpp
@@ -12,17 +12,23 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, bool b_, bool c_, bool d_):
-        a{a_}, b{b_}, c{c_}, d{d_}
-    {}
-    bool a = false, b = false, c = false, d = false;
+namespace flags_test03 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d;
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, bool b_, bool c_, bool d_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d;
+		}
+	};
+
+}
+
+using namespace flags_test03;
 
 
 //-------------------------------------------------------------------

--- a/test/joined_flags_test4.cpp
+++ b/test/joined_flags_test4.cpp
@@ -12,17 +12,24 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, bool b_, bool c_, bool d_):
-        a{a_}, b{b_}, c{c_}, d{d_}
-    {}
-    bool a = false, b = false, c = false, d = false;
+namespace flags_test04 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d;
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, bool b_, bool c_, bool d_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d;
+		}
+	};
+
+}
+
+using namespace flags_test04;
+
 
 
 //-------------------------------------------------------------------

--- a/test/joined_flags_test5.cpp
+++ b/test/joined_flags_test5.cpp
@@ -12,15 +12,21 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, bool b_): a{a_}, b{b_} {}
-    bool a = false, b = false;
+namespace flags_test05 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b);
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, bool b_) : a{ a_ }, b{ b_ } {}
+		bool a = false, b = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b);
+		}
+	};
+
+}
+
+using namespace flags_test05;
 
 
 //-------------------------------------------------------------------

--- a/test/joined_flags_test6.cpp
+++ b/test/joined_flags_test6.cpp
@@ -12,17 +12,23 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, bool b_, bool c_, bool d_):
-        a{a_}, b{b_}, c{c_}, d{d_}
-    {}
-    bool a = false, b = false, c = false, d = false;
+namespace flags_test06 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d);
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, bool b_, bool c_, bool d_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d);
+		}
+	};
+
+}
+
+using namespace flags_test06;
 
 
 //-------------------------------------------------------------------

--- a/test/joined_params_test1.cpp
+++ b/test/joined_params_test1.cpp
@@ -13,21 +13,27 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
+namespace params_test01 {
 
-    explicit
-    active(std::initializer_list<double> il): xs{il} {}
+	struct active {
+		active() = default;
 
-    std::vector<double> xs;
+		explicit
+			active(std::initializer_list<double> il) : xs{ il } {}
 
-    friend bool operator == (const active& a, const active& b) noexcept {
-        return std::equal(begin(a.xs), end(a.xs), begin(b.xs),
-            [](double x, double y) {
-                return std::abs(x - y) < 1e-5;
-            });
-    }
-};
+		std::vector<double> xs;
+
+		friend bool operator == (const active& a, const active& b) noexcept {
+			return std::equal(begin(a.xs), end(a.xs), begin(b.xs),
+				[](double x, double y) {
+					return std::abs(x - y) < 1e-5;
+				});
+		}
+	};
+
+}
+
+using namespace params_test01;
 
 
 //-------------------------------------------------------------------

--- a/test/joined_sequence_test.cpp
+++ b/test/joined_sequence_test.cpp
@@ -12,24 +12,31 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
+namespace sequence_test01 {
 
-    explicit
-    active(int i_, char a_, char b_, char c_) : i{i_}, a{a_}, b{b_}, c{c_} {}
+	struct active {
+		active() = default;
 
-    active(int i_, const std::string& s_) : i{i_}, s{s_} {}
+		explicit
+			active(int i_, char a_, char b_, char c_) : i{ i_ }, a{ a_ }, b{ b_ }, c{ c_ } {}
 
-    int i = 0;
-    char a = ' ', b = ' ', c = ' ';
-    std::string s = "";
+		active(int i_, const std::string& s_) : i{ i_ }, s{ s_ } {}
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.i == y.i &&
-                x.a == y.a && x.b == y.b && x.c == y.c &&
-                x.s == y.s);
-    }
-};
+		int i = 0;
+		char a = ' ', b = ' ', c = ' ';
+		std::string s = "";
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.i == y.i &&
+				x.a == y.a && x.b == y.b && x.c == y.c &&
+				x.s == y.s);
+		}
+	};
+
+}
+
+using namespace sequence_test01;
+
 
 
 //-------------------------------------------------------------------

--- a/test/mixed_params_test.cpp
+++ b/test/mixed_params_test.cpp
@@ -13,28 +13,34 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    int av = 0;
-    int bv = 1;
-    float cv = 0.0f, dv = 1.0f;
-    double ev = 0.0, fv = 1.0;
-    std::string gv;
-    bool a = false, b = false, c = false, d = false, e = false, f = false,
-         g = false, h = false, i = false;
+namespace mixed_params_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        if(x.a != y.a || x.b != y.b || x.c != y.c ||
-           x.d != y.d || x.e != y.e || x.f != y.f ||
-           x.g != y.g || x.h != y.h || x.i != y.i ||
-           x.av != y.av || x.bv != y.bv || x.gv != y.gv) return false;
+	struct active {
+		int av = 0;
+		int bv = 1;
+		float cv = 0.0f, dv = 1.0f;
+		double ev = 0.0, fv = 1.0;
+		std::string gv;
+		bool a = false, b = false, c = false, d = false, e = false, f = false,
+			g = false, h = false, i = false;
 
-        using std::abs;
-        if(abs(x.cv - y.cv) > 1e-4f || abs(x.dv - y.dv) > 1e-4f ||
-           abs(x.ev - y.ev) > 1e-4  || abs(x.fv - y.fv) > 1e-4) return false;
+		friend bool operator == (const active& x, const active& y) noexcept {
+			if (x.a != y.a || x.b != y.b || x.c != y.c ||
+				x.d != y.d || x.e != y.e || x.f != y.f ||
+				x.g != y.g || x.h != y.h || x.i != y.i ||
+				x.av != y.av || x.bv != y.bv || x.gv != y.gv) return false;
 
-        return true;
-    }
-};
+			using std::abs;
+			if (abs(x.cv - y.cv) > 1e-4f || abs(x.dv - y.dv) > 1e-4f ||
+				abs(x.ev - y.ev) > 1e-4 || abs(x.fv - y.fv) > 1e-4) return false;
+
+			return true;
+		}
+	};
+
+}
+
+using namespace mixed_params_test;
 
 
 //-------------------------------------------------------------------

--- a/test/options_test.cpp
+++ b/test/options_test.cpp
@@ -12,19 +12,25 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_):
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}
-    {}
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
+namespace options_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.e == y.e && x.f == y.f);
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }
+		{}
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.e == y.e && x.f == y.f);
+		}
+	};
+
+}
+
+using namespace options_test;
 
 
 //-------------------------------------------------------------------

--- a/test/prefix_test.cpp
+++ b/test/prefix_test.cpp
@@ -12,16 +12,22 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    active(bool a_, int i_): a{a_}, i{i_} {}
-    bool a = false;
-    int i = 0;
+namespace prefix_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.i == y.i);
-    }
-};
+	struct active {
+		active() = default;
+		active(bool a_, int i_) : a{ a_ }, i{ i_ } {}
+		bool a = false;
+		int i = 0;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.i == y.i);
+		}
+	};
+
+}
+
+using namespace prefix_test;
 
 
 //-------------------------------------------------------------------

--- a/test/repeatability_test.cpp
+++ b/test/repeatability_test.cpp
@@ -12,40 +12,46 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
+namespace repeatability_test {
 
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_,
-           std::initializer_list<int> i_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}, i{i_}
-    {}
+	struct active {
+		active() = default;
 
-    bool a = false, b = false, c = false, d = false, e = false, f = false;
-    std::vector<int> i;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_, bool e_, bool f_,
+				std::initializer_list<int> i_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }, i{ i_ }
+		{}
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c &&
-                x.d == y.d && x.e == y.e && x.f == y.f &&
-                std::equal(begin(x.i), end(x.i), begin(y.i)));
-    }
-};
+		bool a = false, b = false, c = false, d = false, e = false, f = false;
+		std::vector<int> i;
 
-struct repeats {
-    repeats() = default;
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c &&
+				x.d == y.d && x.e == y.e && x.f == y.f &&
+				std::equal(begin(x.i), end(x.i), begin(y.i)));
+		}
+	};
 
-    explicit
-    repeats(int a_, int b_, int c_, int d_, int e_, int f_, int i_) :
-        a{a_}, b{b_}, c{c_}, d{d_}, e{e_}, f{f_}, i{i_}
-    {}
+	struct repeats {
+		repeats() = default;
 
-    int a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, i = 0;
+		explicit
+			repeats(int a_, int b_, int c_, int d_, int e_, int f_, int i_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ }, e{ e_ }, f{ f_ }, i{ i_ }
+		{}
 
-    friend bool operator == (const repeats& x, const repeats& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c &&
-                x.d == y.d && x.e == y.e && x.f == y.f && x.i == y.i);
-    }
-};
+		int a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, i = 0;
+
+		friend bool operator == (const repeats& x, const repeats& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c &&
+				x.d == y.d && x.e == y.e && x.f == y.f && x.i == y.i);
+		}
+	};
+
+}
+
+using namespace repeatability_test;
 
 
 //-------------------------------------------------------------------

--- a/test/repeatable_alternatives_test.cpp
+++ b/test/repeatable_alternatives_test.cpp
@@ -12,23 +12,29 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_,
-           std::initializer_list<int> i_, std::initializer_list<int> j_)
-    :
-        a{a_}, b{b_}, i{i_}, j{j_}
-    {}
-    bool a = false, b = false;
-    std::vector<int> i, j;
+namespace repeatable_alts_test {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return x.a == y.a && x.b == y.b &&
-               std::equal(begin(x.i), end(x.i), begin(y.i)) &&
-               std::equal(begin(x.j), end(x.j), begin(y.j));
-    }
-};
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_,
+				std::initializer_list<int> i_, std::initializer_list<int> j_)
+			:
+			a{ a_ }, b{ b_ }, i{ i_ }, j{ j_ }
+		{}
+		bool a = false, b = false;
+		std::vector<int> i, j;
+
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return x.a == y.a && x.b == y.b &&
+				std::equal(begin(x.i), end(x.i), begin(y.i)) &&
+				std::equal(begin(x.j), end(x.j), begin(y.j));
+		}
+	};
+
+}
+
+using namespace repeatable_alts_test;
 
 
 //-------------------------------------------------------------------

--- a/test/required_params_test1.cpp
+++ b/test/required_params_test1.cpp
@@ -12,52 +12,58 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_,
-           int av_, int bv_, int cv_, int dv_):
-        a{a_}, b{b_}, c{c_}, d{d_},
-        av{av_}, bv{bv_}, cv{cv_}, dv{dv_}
-    {}
-    bool a = false, b = false, c = false, d = false;
-    int av = 0, bv = 0, cv = 0, dv = 0;
+namespace required_params_test01 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv );
-    }
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_,
+				int av_, int bv_, int cv_, int dv_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ },
+			av{ av_ }, bv{ bv_ }, cv{ cv_ }, dv{ dv_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+		int av = 0, bv = 0, cv = 0, dv = 0;
 
-    template<class OStream>
-    friend OStream& operator << (OStream& os, const active& x) {
-        return os << '{' << x.a <<' '<< x.b <<' '<< x.c <<' '<< x.d
-            << " | " << x.av <<' '<< x.bv <<' '<< x.cv <<' '<< x.dv << '}';
-    }
-};
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv);
+		}
 
-//---------------------------------------------------------------
-struct errors {
-    errors() = default;
-    explicit
-    errors(bool a_, bool b_, bool c_, bool d_,
-           bool av_, bool bv_, bool cv_, bool dv_):
-        a{a_}, b{b_}, c{c_}, d{d_},
-        av{av_}, bv{bv_}, cv{cv_}, dv{dv_}
-    {}
-    bool a = false, b = false, c = false, d = false;
-    bool av = false, bv = false, cv = false, dv = false;
+		template<class OStream>
+		friend OStream& operator << (OStream& os, const active& x) {
+			return os << '{' << x.a << ' ' << x.b << ' ' << x.c << ' ' << x.d
+				<< " | " << x.av << ' ' << x.bv << ' ' << x.cv << ' ' << x.dv << '}';
+		}
+	};
 
-    friend bool operator == (const errors& x, const errors& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv );
-    }
+	//---------------------------------------------------------------
+	struct errors {
+		errors() = default;
+		explicit
+			errors(bool a_, bool b_, bool c_, bool d_,
+				bool av_, bool bv_, bool cv_, bool dv_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ },
+			av{ av_ }, bv{ bv_ }, cv{ cv_ }, dv{ dv_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+		bool av = false, bv = false, cv = false, dv = false;
 
-    template<class OStream>
-    friend OStream& operator << (OStream& os, const errors& x) {
-        return os << '{' << x.a <<' '<< x.b <<' '<< x.c <<' '<< x.d
-            << " | " << x.av <<' '<< x.bv <<' '<< x.cv <<' '<< x.dv << '}';
-    }
-};
+		friend bool operator == (const errors& x, const errors& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv);
+		}
+
+		template<class OStream>
+		friend OStream& operator << (OStream& os, const errors& x) {
+			return os << '{' << x.a << ' ' << x.b << ' ' << x.c << ' ' << x.d
+				<< " | " << x.av << ' ' << x.bv << ' ' << x.cv << ' ' << x.dv << '}';
+		}
+	};
+
+}
+
+using namespace required_params_test01;
 
 
 //-------------------------------------------------------------------

--- a/test/required_params_test2.cpp
+++ b/test/required_params_test2.cpp
@@ -12,52 +12,58 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
-    explicit
-    active(bool a_, bool b_, bool c_, bool d_,
-           int av_, int bv_, int cv_, int dv_):
-        a{a_}, b{b_}, c{c_}, d{d_},
-        av{av_}, bv{bv_}, cv{cv_}, dv{dv_}
-    {}
-    bool a = false, b = false, c = false, d = false;
-    int av = 0, bv = 0, cv = 0, dv = 0;
+namespace required_params_test02 {
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv );
-    }
+	struct active {
+		active() = default;
+		explicit
+			active(bool a_, bool b_, bool c_, bool d_,
+				int av_, int bv_, int cv_, int dv_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ },
+			av{ av_ }, bv{ bv_ }, cv{ cv_ }, dv{ dv_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+		int av = 0, bv = 0, cv = 0, dv = 0;
 
-    template<class OStream>
-    friend OStream& operator << (OStream& os, const active& x) {
-        return os << '{' << x.a <<' '<< x.b <<' '<< x.c <<' '<< x.d
-            << " | " << x.av <<' '<< x.bv <<' '<< x.cv <<' '<< x.dv << '}';
-    }
-};
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv);
+		}
 
-//---------------------------------------------------------------
-struct errors {
-    errors() = default;
-    explicit
-    errors(bool a_, bool b_, bool c_, bool d_,
-           bool av_, bool bv_, bool cv_, bool dv_):
-        a{a_}, b{b_}, c{c_}, d{d_},
-        av{av_}, bv{bv_}, cv{cv_}, dv{dv_}
-    {}
-    bool a = false, b = false, c = false, d = false;
-    bool av = false, bv = false, cv = false, dv = false;
+		template<class OStream>
+		friend OStream& operator << (OStream& os, const active& x) {
+			return os << '{' << x.a << ' ' << x.b << ' ' << x.c << ' ' << x.d
+				<< " | " << x.av << ' ' << x.bv << ' ' << x.cv << ' ' << x.dv << '}';
+		}
+	};
 
-    friend bool operator == (const errors& x, const errors& y) noexcept {
-        return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
-                x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv );
-    }
+	//---------------------------------------------------------------
+	struct errors {
+		errors() = default;
+		explicit
+			errors(bool a_, bool b_, bool c_, bool d_,
+				bool av_, bool bv_, bool cv_, bool dv_) :
+			a{ a_ }, b{ b_ }, c{ c_ }, d{ d_ },
+			av{ av_ }, bv{ bv_ }, cv{ cv_ }, dv{ dv_ }
+		{}
+		bool a = false, b = false, c = false, d = false;
+		bool av = false, bv = false, cv = false, dv = false;
 
-    template<class OStream>
-    friend OStream& operator << (OStream& os, const errors& x) {
-        return os << '{' << x.a <<' '<< x.b <<' '<< x.c <<' '<< x.d
-            << " | " << x.av <<' '<< x.bv <<' '<< x.cv <<' '<< x.dv << '}';
-    }
-};
+		friend bool operator == (const errors& x, const errors& y) noexcept {
+			return (x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d &&
+				x.av == y.av && x.bv == y.bv && x.cv == y.cv && x.dv == y.dv);
+		}
+
+		template<class OStream>
+		friend OStream& operator << (OStream& os, const errors& x) {
+			return os << '{' << x.a << ' ' << x.b << ' ' << x.c << ' ' << x.d
+				<< " | " << x.av << ' ' << x.bv << ' ' << x.cv << ' ' << x.dv << '}';
+		}
+	};
+
+}
+
+using namespace required_params_test02;
 
 
 //-------------------------------------------------------------------

--- a/test/values_filter_test.cpp
+++ b/test/values_filter_test.cpp
@@ -12,30 +12,37 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
+namespace filter_test01 {
 
-    explicit
-    active(int i_, int j_, int k_,
-           std::size_t l_, std::size_t m_, std::size_t n_,
-           float u_, float v_, float w_,
-           double x_, double y_, double z_)
-    :
-        i{i_}, j{j_}, k{k_}, l{l_}, m{m_}, n{n_},
-        u{u_}, v{v_}, w{w_}, x{x_}, y{y_}, z{z_}
-    {}
+	struct active {
+		active() = default;
 
-    int i = 1, j = 1, k = 1;
-    std::size_t l = 1, m = 1, n = 1;
-    float u = 1.0f, v = 1.0f, w = 1.0f;
-    double x = 1.0, y = 1.0, z = 1.0;
+		explicit
+			active(int i_, int j_, int k_,
+				std::size_t l_, std::size_t m_, std::size_t n_,
+				float u_, float v_, float w_,
+				double x_, double y_, double z_)
+			:
+			i{ i_ }, j{ j_ }, k{ k_ }, l{ l_ }, m{ m_ }, n{ n_ },
+			u{ u_ }, v{ v_ }, w{ w_ }, x{ x_ }, y{ y_ }, z{ z_ }
+		{}
 
-    friend bool operator == (const active& a, const active& b) noexcept {
-        return (a.i == b.i && a.j == b.j && a.k == b.k && a.l == b.l &&
-                a.m == b.m && a.n == b.n && a.u == b.u && a.v == b.v &&
-                a.w == b.w && a.x == b.x && a.y == b.y && a.z == b.z);
-    }
-};
+		int i = 1, j = 1, k = 1;
+		std::size_t l = 1, m = 1, n = 1;
+		float u = 1.0f, v = 1.0f, w = 1.0f;
+		double x = 1.0, y = 1.0, z = 1.0;
+
+		friend bool operator == (const active& a, const active& b) noexcept {
+			return (a.i == b.i && a.j == b.j && a.k == b.k && a.l == b.l &&
+				a.m == b.m && a.n == b.n && a.u == b.u && a.v == b.v &&
+				a.w == b.w && a.x == b.x && a.y == b.y && a.z == b.z);
+		}
+	};
+
+}
+
+using namespace filter_test01;
+
 
 
 //-------------------------------------------------------------------

--- a/test/values_sequencing_test.cpp
+++ b/test/values_sequencing_test.cpp
@@ -12,40 +12,47 @@
 
 
 //-------------------------------------------------------------------
-struct active {
-    active() = default;
+namespace sequencing_test01 {
 
-    explicit
-    active(bool a_,
-           bool ie_, bool je_, bool ke_, bool ve_,
-           int i_, int j_, int k_, std::initializer_list<int> v_)
-    :
-        a{a_},
-        ie{ie_}, je{je_}, ke{ke_}, ve{ve_},
-        i{i_}, j{j_}, k{k_}, v{v_}
-    {}
+	struct active {
+		active() = default;
 
-    //option presence
-    bool a = false;
-    //requirement error
-    bool ie = false, je = false, ke = false, ve = false;
-    //values
-    int i = 0, j = 0, k = 0;
-    std::vector<int> v;
+		explicit
+			active(bool a_,
+				bool ie_, bool je_, bool ke_, bool ve_,
+				int i_, int j_, int k_, std::initializer_list<int> v_)
+			:
+			a{ a_ },
+			ie{ ie_ }, je{ je_ }, ke{ ke_ }, ve{ ve_ },
+			i{ i_ }, j{ j_ }, k{ k_ }, v{ v_ }
+		{}
 
-    friend bool operator == (const active& x, const active& y) noexcept {
-        return (x.a == y.a && x.ie == y.ie && x.je == y.je &&
-                x.ke == y.ke && x.ve == y.ve && x.i == y.i &&
-                x.j == y.j && x.k == y.k &&
-                std::equal(begin(x.v), end(x.v), begin(y.v)));
-    }
+		//option presence
+		bool a = false;
+		//requirement error
+		bool ie = false, je = false, ke = false, ve = false;
+		//values
+		int i = 0, j = 0, k = 0;
+		std::vector<int> v;
 
-    template<class OStream>
-    friend OStream& operator << (OStream& os, const active& x) {
-        return os << x.a <<' '<< x.ie <<' '<< x.je <<' '<< x.ke <<' '
-                  << x.ve <<' '<< x.i <<' '<< x.j <<' '<< x.k;
-    }
-};
+		friend bool operator == (const active& x, const active& y) noexcept {
+			return (x.a == y.a && x.ie == y.ie && x.je == y.je &&
+				x.ke == y.ke && x.ve == y.ve && x.i == y.i &&
+				x.j == y.j && x.k == y.k &&
+				std::equal(begin(x.v), end(x.v), begin(y.v)));
+		}
+
+		template<class OStream>
+		friend OStream& operator << (OStream& os, const active& x) {
+			return os << x.a << ' ' << x.ie << ' ' << x.je << ' ' << x.ke << ' '
+				<< x.ve << ' ' << x.i << ' ' << x.j << ' ' << x.k;
+		}
+	};
+
+}
+
+using namespace sequencing_test01;
+
 
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
fix for MSVC2019 going bonkers about the various `struct active` in the tests mixing them up in monolithic builds: 

by placing each within its own namespace do we prevent this confusion. 

(NOT CHECKED ASSUMPTION: probably due to the MSVC2019 compiler being configured to compile at link time in my projects, but that's just a hunch. Fact is the `/RTC1` debug mode checks built in by the compiler fire up in multiple places about corruption "around the variable m" which is a `struct active` instance in several tests. Having those structs in a namespace and then using the test-specific namespace in *that* test resolves this compiler issue.)

---

## Postscript:

Included this patch with the other pull reqs FYI; this one is rather niche as it only becomes an issue when you merge all those test programs together into a single one and compile it into a single binary (hence "monolithic build").

Reject & close if you don't like it, no sweat.


(cherrypicked off https://github.com/GerHobbelt/clipp master branch; original commit tested with latest MSVC2019)