### PR TITLE
Add support to store values in std::optional variables.

### DIFF
--- a/include/clipp.h
+++ b/include/clipp.h
@@ -46,6 +46,10 @@
 #include <iterator>
 #include <functional>
 
+#if __cplusplus >= 201703L
+#include <optional>
+#endif
+
 
 /*************************************************************************//**
  *
@@ -471,7 +475,14 @@ struct make<std::string> {
     }
 };
 
-
+#if __cplusplus >= 201703L
+template<class T>
+struct make<std::optional<T>> {
+  static inline std::optional<T> from(const char* s) {
+    return std::make_optional<T>(make<T>::from(s));
+  }
+};
+#endif
 
 /*************************************************************************//**
  *


### PR DESCRIPTION
This allows to use clipp::value("foo", myoptional) directly as in:
```
std::optional<int> foo;

auto cli = (clipp::option("-n"), clipp::value("howmany", foo));
```

This is not strictly required as generally one can work with defaults, but I feel is a nice semantic addition.